### PR TITLE
refactor brsa_keypair_generate() to fail early if sk or pk are NULL

### DIFF
--- a/src/blind_rsa.c
+++ b/src/blind_rsa.c
@@ -153,6 +153,9 @@ brsa_publickey_recover(BRSAPublicKey *pk, const BRSASecretKey *sk)
 int
 brsa_keypair_generate(BRSASecretKey *sk, BRSAPublicKey *pk, int modulus_bits)
 {
+    if (sk == NULL || pk == NULL)
+        return 0;
+
     sk->evp_pkey = NULL;
     pk->evp_pkey = NULL;
     pk->mont_ctx = NULL;
@@ -181,10 +184,7 @@ brsa_keypair_generate(BRSASecretKey *sk, BRSAPublicKey *pk, int modulus_bits)
     }
     EVP_PKEY_assign_RSA(sk->evp_pkey, rsa);
 
-    if (pk != NULL) {
-        return brsa_publickey_recover(pk, sk);
-    }
-    return 0;
+    return brsa_publickey_recover(pk, sk);
 }
 
 int


### PR DESCRIPTION
This PR refactors `brsa_keypair_generate()` to return 0 earlier if `sk` or `pk` are NULL as they are assumed to be not null in the assignments on L156-158
```
    sk->evp_pkey = NULL;
    pk->evp_pkey = NULL;
    pk->mont_ctx = NULL;
```

The null check on L184 is then removed to avoid deadcode.